### PR TITLE
Fix for "Edit this page on GitHub" link in the footer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Winterbloom Order Queue
 copyright: "© 2020 Winterbloom, licensed under Creative Commons CC BY-SA 4.0"
 repo_url: "https://github.com/wntrblm/queue.winterbloom.com"
-edit_uri: edit/main/user_guide/docs
+edit_uri: edit/main/docs
 site_url: https://queue.winterbloom.com
 theme:
     name: winterbloom


### PR DESCRIPTION
Hi Thea!

I noticed the "Edit this page on GitHub" link in the footer of the Queue page redirects to an invalid URL on GitHub. I'm not super familiar with mkdocs but in comparing this repo with the Castor and Pollux User Guide, I believe this should correct the issue. Please let me know if this change would introduce any other new problems.

I also noticed the navigation links don't show up (especially noticeable on mobile with the empty hamburger menu). The `nav` property seems correct, so I'm hoping this change would fix that as well.

Thank you for making this Queue page, it is so helpful!
